### PR TITLE
Don't test on 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"


### PR DESCRIPTION
node-sass requires `>=0.10`
